### PR TITLE
fix compilation error due to missing file (in missing bower dependency)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "normalize-opentype.css": "^0.2.4",
     "svgxuse": "^1.1.21",
     "Font-Awesome-SVG-PNG": "font-awesome-svg-png#^1.1.5",
-    "SparkMD5": "^2.0.2"
+    "SparkMD5": "^2.0.2",
+    "lazyload-image": "^2.1.0"
   }
 }


### PR DESCRIPTION
this is my first attempt to build and use sweetroll (which looks awesome btw!) - i could only get this to build by adding `lazyload-image` as Bower dependency in `bower.json`.

(i am not sure whether the previous auto-commit with log message *Gitson transaction* should be included in the PR)