### PR TITLE
allow to fetch myfreeweb dependencies directly from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ I haven't uploaded any yet, so you have to build from source.
 
 - get [stack] \(from your OS package manager or `cabal install stack`)
 - get [bower] \(get node/[npm](https://www.npmjs.com) from your OS package manager, `npm install -g bower`)
+- install the Duktape development files (details depend on OS; e.g. in Debian `apt install duktape-dev`)
 - `git clone` the repo
 - `cd` into it
 - `bower install`
@@ -109,6 +110,10 @@ The `:serve` command in ghci runs the server in test mode, which means you don't
 $ bower install
 
 $ stack build
+
+# (or, if using local development copies of the myfreeweb dependencies, use
+# the alternative stack-dev.yaml instead):
+# $ stack --stack-yaml stack-dev.yaml build
 
 $ stack test
 

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "normalize-opentype.css": "^0.2.4",
     "svgxuse": "^1.1.21",
     "Font-Awesome-SVG-PNG": "font-awesome-svg-png#^1.1.5",
-    "SparkMD5": "^2.0.2"
+    "SparkMD5": "^2.0.2",
+    "lazyload-image": "^2.1.0"
   }
 }

--- a/stack-dev.yaml
+++ b/stack-dev.yaml
@@ -1,0 +1,20 @@
+flags:
+  highlighting-kate: { pcre-light: true }
+packages:
+  - '.'
+  - location: '../indieweb-algorithms'
+    extra-dep: true
+  - location: '../hs-duktape'
+    extra-dep: true
+  - location: '../pcre-heavy'
+    extra-dep: true
+  - location: '../microformats2-parser'
+    extra-dep: true
+  - location: '../gitson'
+    extra-dep: true
+  - location: '../http-link-header'
+    extra-dep: true
+extra-deps:
+  - git-embed-0.1.0
+  - highlighting-kate-0.6.3
+resolver: nightly-2016-11-12

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,17 +2,29 @@ flags:
   highlighting-kate: { pcre-light: true }
 packages:
   - '.'
-  - location: '../indieweb-algorithms'
+  - location:
+      git: https://github.com/myfreeweb/indieweb-algorithms.git
+      commit: 3a70a6bee81dcb4c1b65a3081ff0c250c64f0fc6
     extra-dep: true
-  - location: '../hs-duktape'
+  - location:
+      git: https://github.com/myfreeweb/hs-duktape.git
+      commit: 1ab03a588dd38eb7e3a33502b941733bf810ddeb
     extra-dep: true
-  - location: '../pcre-heavy'
+  - location:
+      git: https://github.com/myfreeweb/pcre-heavy.git
+      commit: 9873fb019873340b212780d12595c0f66ec88613
     extra-dep: true
-  - location: '../microformats2-parser'
+  - location:
+      git: https://github.com/myfreeweb/microformats2-parser.git
+      commit: cdd16012a6d367c4256ba4585737b2b94ac60c42
     extra-dep: true
-  - location: '../gitson'
+  - location:
+      git: https://github.com/myfreeweb/gitson.git
+      commit: 90c85dbf5fddd6fc4a84bcc1d491293e5e9414ec
     extra-dep: true
-  - location: '../http-link-header'
+  - location:
+      git: https://github.com/myfreeweb/http-link-header.git
+      commit: ab530b746f7c1daf648ffbfd700340de2c91e12e
     extra-dep: true
 extra-deps:
   - git-embed-0.1.0


### PR DESCRIPTION
This should fix #4.

Not sure why the commit from my previous PR (#3) got included in this PR: i guess i just need more Sunday morning coffee.

(I have also updated the documentation referencing `stack-dev.yaml` for local dev builds, and adding a reference to the dev package for duktape being needed for hs-duktape to be built successfully)